### PR TITLE
feat: add express backend and angular integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+# Backend
+backend/node_modules/
+backend/.env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=
+MODEL=gpt-4o-mini
+PORT=3001

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "perfil-backend",
+  "version": "1.0.0",
+  "description": "Backend para geração de cartas Perfil 7",
+  "type": "module",
+  "main": "src/server.ts",
+  "scripts": {
+    "start": "node --loader ts-node/esm src/server.ts",
+    "test": "echo \"no tests\""
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "openai": "^4.53.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,111 @@
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+import OpenAI from 'openai';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+const MODEL = process.env.MODEL ?? 'gpt-4o-mini';
+
+type Categoria = 'Digital' | 'Pessoa' | 'Lugar' | 'Coisa' | 'Ano';
+
+const ACOES = [
+  'Perca sua vez',
+  'Avance 1 casa', 'Avance 2 casas', 'Avance 3 casas',
+  'Volte 1 casa', 'Volte 2 casas', 'Volte 3 casas',
+  'Ganhe uma ficha azul'
+];
+
+const schema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    categoria: { type: 'string' },
+    resposta: { type: 'string' },
+    linhas: {
+      type: 'array',
+      minItems: 20,
+      maxItems: 20,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          tipo: { enum: ['dica','acao'] },
+          texto: { type: 'string' },
+          dificuldade: { enum: ['facil','media','dificil', 'n/a'] }
+        },
+        required: ['tipo','texto','dificuldade']
+      }
+    }
+  },
+  required: ['categoria','resposta','linhas']
+};
+
+function buildSystemPrompt() {
+  return [
+    'Você é um gerador de cartas estilo Perfil 7.',
+    'Formato final: exatamente 20 linhas numeradas; cada linha pode ser uma DICA ou uma AÇÃO.',
+    'Distribuição: 14–16 DICAs e 4–6 AÇÕEs, em ordem aleatória.',
+    'A dificuldade das DICAs deve ser misturada (fácil, média, difícil) sem ordem previsível.',
+    'Evite falar a resposta literalmente nas primeiras 10 linhas.',
+    'A resposta pode “entregar” entre as linhas 14–20 (não necessariamente a última).',
+    'Não use o nome da resposta nas dicas iniciais; use descrições, fatos, pistas.',
+    'Ações permitidas exatamente como: "Perca sua vez", "Avance X casas", "Volte X casas", "Ganhe uma ficha azul".'
+  ].join('\n');
+}
+
+function buildUserPrompt(categoria: Categoria, resposta?: string) {
+  return [
+    `Categoria: ${categoria}`,
+    resposta ? `Resposta final (obrigatória): ${resposta}` : 'Escolha uma resposta adequada e popular para a categoria.',
+    'Produza 20 linhas com variedade, sem ordem de dificuldade, com tom fiel ao jogo.',
+  ].join('\n');
+}
+
+app.post('/cards', async (req, res) => {
+  try {
+    const categoria: Categoria = req.body?.categoria ?? ['Digital','Pessoa','Lugar','Coisa','Ano'][Math.floor(Math.random()*5)] as Categoria;
+    const resposta: string | undefined = req.body?.resposta;
+
+    const response = await openai.responses.create({
+      model: MODEL,
+      response_format: { type: 'json_schema', json_schema: { name: 'Perfil7Card', schema } },
+      input: [
+        { role: 'system', content: buildSystemPrompt() },
+        { role: 'user', content: buildUserPrompt(categoria, resposta) },
+        { role: 'user', content: 'Exemplo de AÇÃO: "Avance 2 casas". Exemplo de DICA: "Sou usado para pagamentos instantâneos no Brasil".' }
+      ],
+    });
+
+    const json = JSON.parse(response.output[0].content[0].text) as {
+      categoria: string; resposta: string;
+      linhas: { tipo:'dica'|'acao'; texto:string; dificuldade:'facil'|'media'|'dificil'|'n/a'}[];
+    };
+
+    let linhas = json.linhas.map(l => {
+      if (l.tipo === 'acao') {
+        const match = ACOES.find(a => l.texto.toLowerCase().startsWith(a.toLowerCase()));
+        return { ...l, texto: match ?? 'Perca sua vez', dificuldade: 'n/a' };
+      }
+      return l;
+    });
+
+    linhas = linhas
+      .map(v => ({ v, r: Math.random() }))
+      .sort((a,b)=>a.r-b.r)
+      .map(({v})=>v)
+      .slice(0,20);
+
+    res.json({ categoria: json.categoria, resposta: json.resposta, linhas });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: err?.message ?? 'Erro ao gerar carta' });
+  }
+});
+
+app.listen(process.env.PORT ?? 3001, () => {
+  console.log(`Perfil7 IA rodando na porta ${process.env.PORT ?? 3001}`);
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/perfil-generator/src/app/app.component.html
+++ b/perfil-generator/src/app/app.component.html
@@ -1,8 +1,9 @@
 <div class="container">
   <app-card
+    *ngIf="carta"
     [categoria]="carta.categoria"
     [resposta]="carta.resposta"
-    [dicas]="carta.dicas"
+    [linhas]="carta.linhas"
   >
   </app-card>
   <button (click)="novaCarta()">Gerar Nova Carta</button>

--- a/perfil-generator/src/app/app.component.spec.ts
+++ b/perfil-generator/src/app/app.component.spec.ts
@@ -1,10 +1,19 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AppComponent } from './app.component';
+import { CardGeneratorService, Carta } from './services/card-generator.service';
+
+class MockCardGeneratorService {
+  gerarCarta() {
+    return of({ categoria: 'Digital', resposta: 'Exemplo', linhas: [] } as Carta);
+  }
+}
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [{ provide: CardGeneratorService, useClass: MockCardGeneratorService }]
     }).compileComponents();
   });
 
@@ -12,18 +21,5 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
-  });
-
-  it(`should have the 'perfil-generator' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('perfil-generator');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, perfil-generator');
   });
 });

--- a/perfil-generator/src/app/app.component.ts
+++ b/perfil-generator/src/app/app.component.ts
@@ -1,24 +1,23 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-// import { RouterOutlet } from '@angular/router';
-
-import { CardGeneratorService } from './services/card-generator.service';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, OnInit } from '@angular/core';
+import { CardGeneratorService, Carta } from './services/card-generator.service';
 
 @Component({
   selector: 'app-root',
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   standalone: true,
-  providers: [CardGeneratorService],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {
-  carta: any;
+export class AppComponent implements OnInit {
+  carta: Carta | null = null;
 
-  constructor(private gerador: CardGeneratorService) {
-    this.carta = this.gerador.gerarCarta();
+  constructor(private gerador: CardGeneratorService) {}
+
+  ngOnInit() {
+    this.novaCarta();
   }
 
   novaCarta() {
-    this.carta = this.gerador.gerarCarta();
+    this.gerador.gerarCarta().subscribe((c) => this.carta = c);
   }
 }

--- a/perfil-generator/src/app/app.config.ts
+++ b/perfil-generator/src/app/app.config.ts
@@ -1,8 +1,13 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideHttpClient()
+  ]
 };

--- a/perfil-generator/src/app/components/card/card.component.html
+++ b/perfil-generator/src/app/components/card/card.component.html
@@ -4,6 +4,6 @@
     <span class="resposta">{{ resposta }}</span>
   </div>
   <ol class="dicas">
-    <li *ngFor="let dica of dicas">{{ dica }}</li>
+    <li *ngFor="let linha of linhas" [class.acao]="linha.tipo === 'acao'">{{ linha.texto }}</li>
   </ol>
 </div>

--- a/perfil-generator/src/app/components/card/card.component.scss
+++ b/perfil-generator/src/app/components/card/card.component.scss
@@ -30,5 +30,10 @@
   .dicas {
     margin-top: 10px;
     padding-left: 20px;
+
+    .acao {
+      color: #d00;
+      font-weight: bold;
+    }
   }
 }

--- a/perfil-generator/src/app/components/card/card.component.ts
+++ b/perfil-generator/src/app/components/card/card.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { Linha } from '../../services/card-generator.service';
 
 @Component({
   selector: 'app-card',
@@ -8,5 +9,5 @@ import { Component, Input } from '@angular/core';
 export class CardComponent {
   @Input() categoria!: string;
   @Input() resposta!: string;
-  @Input() dicas!: string[];
+  @Input() linhas!: Linha[];
 }

--- a/perfil-generator/src/app/services/card-generator.service.ts
+++ b/perfil-generator/src/app/services/card-generator.service.ts
@@ -1,77 +1,26 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Linha {
+  tipo: 'dica' | 'acao';
+  texto: string;
+  dificuldade: 'facil' | 'media' | 'dificil' | 'n/a';
+}
+
+export interface Carta {
+  categoria: string;
+  resposta: string;
+  linhas: Linha[];
+}
 
 @Injectable({ providedIn: 'root' })
 export class CardGeneratorService {
+  private apiUrl = 'http://localhost:3001/cards';
 
-  private categorias = ['Digital', 'Pessoa', 'Lugar', 'Coisa', 'Ano'];
+  constructor(private http: HttpClient) {}
 
-  private acoesEspeciais = [
-    'Perca sua vez',
-    'Avance 1 casa',
-    'Avance 2 casas',
-    'Avance 3 casas',
-    'Volte 1 casa',
-    'Volte 2 casas',
-    'Volte 3 casas',
-    'Ganhe uma ficha azul'
-  ];
-
-  gerarCarta(): any {
-    const categoria = this.sortearCategoria();
-    const resposta = this.gerarRespostaExemplo(categoria); // futuramente, IA ou lista
-    const dicas = this.gerarDicas(categoria, resposta);
-
-    return { categoria, resposta, dicas };
-  }
-
-  private sortearCategoria() {
-    return this.categorias[Math.floor(Math.random() * this.categorias.length)];
-  }
-
-  private gerarRespostaExemplo(categoria: string): string {
-    const exemplos: any = {
-      Digital: ['Instagram', 'Pix', 'Google', 'TikTok'],
-      Pessoa: ['Albert Einstein', 'Ayrton Senna', 'Harry Potter', 'Cleópatra'],
-      Lugar: ['Gotham City', 'Paris', 'Deserto do Saara', 'Capivari'],
-      Coisa: ['Molho Barbecue', 'Cafeteira Elétrica', 'Violão', 'Skate'],
-      Ano: ['1969', '2000', '1985', '2020']
-    };
-    const lista = exemplos[categoria];
-    return lista[Math.floor(Math.random() * lista.length)];
-  }
-
-  private gerarDicas(categoria: string, resposta: string): string[] {
-    const dicasGeradas: string[] = [];
-
-    // Criar dicas simuladas (aqui será a IA futuramente)
-    for (let i = 0; i < 14; i++) {
-      dicasGeradas.push(this.gerarDicaFake(categoria, resposta));
-    }
-
-    // Adicionar ações especiais
-    const totalAcoes = Math.floor(Math.random() * 3) + 4; // entre 4 e 6
-    for (let i = 0; i < totalAcoes; i++) {
-      dicasGeradas.push(this.sortearAcaoEspecial());
-    }
-
-    // Embaralhar
-    return this.embaralharArray(dicasGeradas).slice(0, 20);
-  }
-
-  private gerarDicaFake(categoria: string, resposta: string): string {
-    const niveis = ['(difícil)', '(média)', '(fácil)'];
-    const nivel = niveis[Math.floor(Math.random() * niveis.length)];
-    return `Dica sobre ${categoria} ${nivel}`;
-  }
-
-  private sortearAcaoEspecial(): string {
-    return this.acoesEspeciais[Math.floor(Math.random() * this.acoesEspeciais.length)];
-  }
-
-  private embaralharArray(array: any[]): any[] {
-    return array
-      .map(value => ({ value, sort: Math.random() }))
-      .sort((a, b) => a.sort - b.sort)
-      .map(({ value }) => value);
+  gerarCarta(categoria?: string, resposta?: string): Observable<Carta> {
+    return this.http.post<Carta>(this.apiUrl, { categoria, resposta });
   }
 }


### PR DESCRIPTION
## Summary
- add Node/Express backend using OpenAI to generate Perfil 7 cards
- integrate Angular frontend with backend via HttpClient and render action/dica lines
- style action lines and adjust tests

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897677300b083238c988f896c05edad